### PR TITLE
Extend rpc configuration in userop.js to support ConnectionInfo

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -20,10 +20,13 @@ export class Client implements IClient {
   public waitTimeoutMs: number;
   public waitIntervalMs: number;
 
-  private constructor(rpcUrlOrConnectionInfo: string | ConnectionInfo, opts?: IClientOpts) {
-    this.provider = new BundlerJsonRpcProvider(rpcUrlOrConnectionInfo).setBundlerRpc(
-      opts?.overrideBundlerRpc
-    );
+  private constructor(
+    rpcUrlOrConnectionInfo: string | ConnectionInfo,
+    opts?: IClientOpts
+  ) {
+    this.provider = new BundlerJsonRpcProvider(
+      rpcUrlOrConnectionInfo
+    ).setBundlerRpc(opts?.overrideBundlerRpc);
     this.entryPoint = EntryPoint__factory.connect(
       opts?.entryPoint || ERC4337.EntryPoint,
       this.provider
@@ -33,7 +36,10 @@ export class Client implements IClient {
     this.waitIntervalMs = 5000;
   }
 
-  public static async init(rpcUrlOrConnectionInfo: string | ConnectionInfo, opts?: IClientOpts) {
+  public static async init(
+    rpcUrlOrConnectionInfo: string | ConnectionInfo,
+    opts?: IClientOpts
+  ) {
     const instance = new Client(rpcUrlOrConnectionInfo, opts);
     instance.chainId = await instance.provider
       .getNetwork()

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,15 +1,16 @@
 import { BigNumberish, ethers } from "ethers";
+import { ConnectionInfo } from "ethers/lib/utils";
+import { ERC4337 } from "./constants";
+import { UserOperationMiddlewareCtx } from "./context";
+import { BundlerJsonRpcProvider } from "./provider";
+import { EntryPoint, EntryPoint__factory } from "./typechain";
 import {
   IClient,
-  IUserOperationBuilder,
-  ISendUserOperationOpts,
   IClientOpts,
+  ISendUserOperationOpts,
+  IUserOperationBuilder,
 } from "./types";
-import { EntryPoint, EntryPoint__factory } from "./typechain";
 import { OpToJSON } from "./utils";
-import { UserOperationMiddlewareCtx } from "./context";
-import { ERC4337 } from "./constants";
-import { BundlerJsonRpcProvider } from "./provider";
 
 export class Client implements IClient {
   private provider: ethers.providers.JsonRpcProvider;
@@ -19,8 +20,8 @@ export class Client implements IClient {
   public waitTimeoutMs: number;
   public waitIntervalMs: number;
 
-  private constructor(rpcUrl: string, opts?: IClientOpts) {
-    this.provider = new BundlerJsonRpcProvider(rpcUrl).setBundlerRpc(
+  private constructor(rpcUrlOrConnectionInfo: string | ConnectionInfo, opts?: IClientOpts) {
+    this.provider = new BundlerJsonRpcProvider(rpcUrlOrConnectionInfo).setBundlerRpc(
       opts?.overrideBundlerRpc
     );
     this.entryPoint = EntryPoint__factory.connect(
@@ -32,8 +33,8 @@ export class Client implements IClient {
     this.waitIntervalMs = 5000;
   }
 
-  public static async init(rpcUrl: string, opts?: IClientOpts) {
-    const instance = new Client(rpcUrl, opts);
+  public static async init(rpcUrlOrConnectionInfo: string | ConnectionInfo, opts?: IClientOpts) {
+    const instance = new Client(rpcUrlOrConnectionInfo, opts);
     instance.chainId = await instance.provider
       .getNetwork()
       .then((network) => ethers.BigNumber.from(network.chainId));

--- a/src/preset/builder/kernel.ts
+++ b/src/preset/builder/kernel.ts
@@ -1,28 +1,29 @@
 import { ethers } from "ethers";
-import { ERC4337, Kernel as KernelConst } from "../../constants";
+import { ConnectionInfo } from "ethers/lib/utils";
 import { UserOperationBuilder } from "../../builder";
+import { ERC4337, Kernel as KernelConst } from "../../constants";
+import { Safe } from "../../constants/safe";
 import { BundlerJsonRpcProvider } from "../../provider";
 import {
-  EOASignature,
-  estimateUserOperationGas,
-  getGasPrice,
-} from "../middleware";
-import {
-  EntryPoint,
-  EntryPoint__factory,
   ECDSAKernelFactory,
   ECDSAKernelFactory__factory,
+  EntryPoint,
+  EntryPoint__factory,
   Kernel as KernelImpl,
   Kernel__factory,
   Multisend,
   Multisend__factory,
 } from "../../typechain";
 import {
-  IPresetBuilderOpts,
   ICall,
+  IPresetBuilderOpts,
   UserOperationMiddlewareFn,
 } from "../../types";
-import { Safe } from "../../constants/safe";
+import {
+  EOASignature,
+  estimateUserOperationGas,
+  getGasPrice,
+} from "../middleware";
 
 enum Operation {
   Call,
@@ -40,12 +41,12 @@ export class Kernel extends UserOperationBuilder {
 
   private constructor(
     signer: ethers.Signer,
-    rpcUrl: string,
+    rpcUrlOrConnectionInfo: string | ConnectionInfo,
     opts?: IPresetBuilderOpts
   ) {
     super();
     this.signer = signer;
-    this.provider = new BundlerJsonRpcProvider(rpcUrl).setBundlerRpc(
+    this.provider = new BundlerJsonRpcProvider(rpcUrlOrConnectionInfo).setBundlerRpc(
       opts?.overrideBundlerRpc
     );
     this.entryPoint = EntryPoint__factory.connect(
@@ -81,10 +82,10 @@ export class Kernel extends UserOperationBuilder {
 
   public static async init(
     signer: ethers.Signer,
-    rpcUrl: string,
+    rpcUrlOrConnectionInfo: string | ConnectionInfo,
     opts?: IPresetBuilderOpts
   ): Promise<Kernel> {
-    const instance = new Kernel(signer, rpcUrl, opts);
+    const instance = new Kernel(signer, rpcUrlOrConnectionInfo, opts);
 
     try {
       instance.initCode = await ethers.utils.hexConcat([

--- a/src/preset/builder/kernel.ts
+++ b/src/preset/builder/kernel.ts
@@ -46,9 +46,9 @@ export class Kernel extends UserOperationBuilder {
   ) {
     super();
     this.signer = signer;
-    this.provider = new BundlerJsonRpcProvider(rpcUrlOrConnectionInfo).setBundlerRpc(
-      opts?.overrideBundlerRpc
-    );
+    this.provider = new BundlerJsonRpcProvider(
+      rpcUrlOrConnectionInfo
+    ).setBundlerRpc(opts?.overrideBundlerRpc);
     this.entryPoint = EntryPoint__factory.connect(
       opts?.entryPoint || ERC4337.EntryPoint,
       this.provider

--- a/src/preset/builder/simpleAccount.ts
+++ b/src/preset/builder/simpleAccount.ts
@@ -33,9 +33,9 @@ export class SimpleAccount extends UserOperationBuilder {
   ) {
     super();
     this.signer = signer;
-    this.provider = new BundlerJsonRpcProvider(rpcUrlOrConnectionInfo).setBundlerRpc(
-      opts?.overrideBundlerRpc
-    );
+    this.provider = new BundlerJsonRpcProvider(
+      rpcUrlOrConnectionInfo
+    ).setBundlerRpc(opts?.overrideBundlerRpc);
     this.entryPoint = EntryPoint__factory.connect(
       opts?.entryPoint || ERC4337.EntryPoint,
       this.provider

--- a/src/preset/builder/simpleAccount.ts
+++ b/src/preset/builder/simpleAccount.ts
@@ -1,12 +1,8 @@
 import { BigNumberish, BytesLike, ethers } from "ethers";
-import { ERC4337 } from "../../constants";
+import { ConnectionInfo } from "ethers/lib/utils";
 import { UserOperationBuilder } from "../../builder";
+import { ERC4337 } from "../../constants";
 import { BundlerJsonRpcProvider } from "../../provider";
-import {
-  EOASignature,
-  estimateUserOperationGas,
-  getGasPrice,
-} from "../middleware";
 import {
   EntryPoint,
   EntryPoint__factory,
@@ -16,6 +12,11 @@ import {
   SimpleAccount__factory,
 } from "../../typechain";
 import { IPresetBuilderOpts, UserOperationMiddlewareFn } from "../../types";
+import {
+  EOASignature,
+  estimateUserOperationGas,
+  getGasPrice,
+} from "../middleware";
 
 export class SimpleAccount extends UserOperationBuilder {
   private signer: ethers.Signer;
@@ -27,12 +28,12 @@ export class SimpleAccount extends UserOperationBuilder {
 
   private constructor(
     signer: ethers.Signer,
-    rpcUrl: string,
+    rpcUrlOrConnectionInfo: string | ConnectionInfo,
     opts?: IPresetBuilderOpts
   ) {
     super();
     this.signer = signer;
-    this.provider = new BundlerJsonRpcProvider(rpcUrl).setBundlerRpc(
+    this.provider = new BundlerJsonRpcProvider(rpcUrlOrConnectionInfo).setBundlerRpc(
       opts?.overrideBundlerRpc
     );
     this.entryPoint = EntryPoint__factory.connect(
@@ -57,10 +58,10 @@ export class SimpleAccount extends UserOperationBuilder {
 
   public static async init(
     signer: ethers.Signer,
-    rpcUrl: string,
+    rpcUrlOrConnectionInfo: string | ConnectionInfo,
     opts?: IPresetBuilderOpts
   ): Promise<SimpleAccount> {
-    const instance = new SimpleAccount(signer, rpcUrl, opts);
+    const instance = new SimpleAccount(signer, rpcUrlOrConnectionInfo, opts);
 
     try {
       instance.initCode = await ethers.utils.hexConcat([

--- a/src/preset/middleware/paymaster.ts
+++ b/src/preset/middleware/paymaster.ts
@@ -12,7 +12,10 @@ interface VerifyingPaymasterResult {
 
 // Assumes the paymaster interface in https://hackmd.io/@stackup/H1oIvV-qi
 export const verifyingPaymaster =
-  (paymasterRpc: string | ConnectionInfo, context: any): UserOperationMiddlewareFn =>
+  (
+    paymasterRpc: string | ConnectionInfo,
+    context: any
+  ): UserOperationMiddlewareFn =>
   async (ctx) => {
     ctx.op.verificationGasLimit = ethers.BigNumber.from(
       ctx.op.verificationGasLimit

--- a/src/preset/middleware/paymaster.ts
+++ b/src/preset/middleware/paymaster.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { ConnectionInfo } from "ethers/lib/utils";
 import { UserOperationMiddlewareFn } from "../../types";
 import { OpToJSON } from "../../utils";
 
@@ -11,7 +12,7 @@ interface VerifyingPaymasterResult {
 
 // Assumes the paymaster interface in https://hackmd.io/@stackup/H1oIvV-qi
 export const verifyingPaymaster =
-  (paymasterRpc: string, context: any): UserOperationMiddlewareFn =>
+  (paymasterRpc: string | ConnectionInfo, context: any): UserOperationMiddlewareFn =>
   async (ctx) => {
     ctx.op.verificationGasLimit = ethers.BigNumber.from(
       ctx.op.verificationGasLimit

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -10,7 +10,9 @@ export class BundlerJsonRpcProvider extends ethers.providers.JsonRpcProvider {
     "eth_supportedEntryPoints",
   ]);
 
-  setBundlerRpc(bundlerRpc?: string | ethers.utils.ConnectionInfo): BundlerJsonRpcProvider {
+  setBundlerRpc(
+    bundlerRpc?: string | ethers.utils.ConnectionInfo
+  ): BundlerJsonRpcProvider {
     if (bundlerRpc) {
       this.bundlerRpc = new ethers.providers.JsonRpcProvider(bundlerRpc);
     }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -10,7 +10,7 @@ export class BundlerJsonRpcProvider extends ethers.providers.JsonRpcProvider {
     "eth_supportedEntryPoints",
   ]);
 
-  setBundlerRpc(bundlerRpc?: string): BundlerJsonRpcProvider {
+  setBundlerRpc(bundlerRpc?: string | ethers.utils.ConnectionInfo): BundlerJsonRpcProvider {
     if (bundlerRpc) {
       this.bundlerRpc = new ethers.providers.JsonRpcProvider(bundlerRpc);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { BigNumberish, BytesLike } from "ethers";
+import { ConnectionInfo } from "ethers/lib/utils";
 import { UserOperationEventEvent } from "./typechain/EntryPoint";
 
 export interface IUserOperation {
@@ -90,7 +91,7 @@ export interface IClient {
 
 export interface IClientOpts {
   entryPoint?: string;
-  overrideBundlerRpc?: string;
+  overrideBundlerRpc?: string | ConnectionInfo;
 }
 
 export interface ISendUserOperationOpts {
@@ -107,7 +108,7 @@ export interface IPresetBuilderOpts {
   entryPoint?: string;
   factory?: string;
   paymasterMiddleware?: UserOperationMiddlewareFn;
-  overrideBundlerRpc?: string;
+  overrideBundlerRpc?: string | ConnectionInfo;
 }
 
 export interface ICall {


### PR DESCRIPTION
This PR modifies the `userop.js` library to allow for more extensive rpc configurations. Previously, the rpc configuration only accepted a URL string. However, there was a need to set additional request parameters beyond the URL, such as headers. 

To address this, the type of rpc configuration parameters has been extended from `rpc?: string` to `rpc?: string | ConnectionInfo`. The `ConnectionInfo` type, which comes from the `ethers` library, allows for the setting of a wider range of parameters, such as headers, in addition to the URL.
