### PR TITLE
fix: Add check for whether account is deployed

### DIFF
--- a/src/preset/builder/simpleAccount.ts
+++ b/src/preset/builder/simpleAccount.ts
@@ -52,7 +52,9 @@ export class SimpleAccount extends UserOperationBuilder {
 
   private resolveAccount: UserOperationMiddlewareFn = async (ctx) => {
     ctx.op.nonce = await this.entryPoint.getNonce(ctx.op.sender, 0);
-    ctx.op.initCode = ctx.op.nonce.eq(0) ? this.initCode : "0x";
+    const code = await this.provider.getCode(this.proxy.address)
+    const ifNotDeployed = code === "0x";
+    ctx.op.initCode = ifNotDeployed ? this.initCode : "0x";
   };
 
   public static async init(

--- a/src/preset/middleware/gasLimit.ts
+++ b/src/preset/middleware/gasLimit.ts
@@ -12,6 +12,9 @@ const estimateCreationGas = async (
   provider: ethers.providers.JsonRpcProvider,
   initCode: BytesLike
 ): Promise<ethers.BigNumber> => {
+  if (initCode.length <= 20) {
+    return ethers.BigNumber.from(0);
+  }
   const initCodeHex = ethers.utils.hexlify(initCode);
   const factory = initCodeHex.substring(0, 42);
   const callData = "0x" + initCodeHex.substring(42);


### PR DESCRIPTION
## What?
This PR updates both [simpleAccount.ts](https://github.com/stackup-wallet/userop.js/blob/db3258c5a20cef480d79ec6290094a4a6f89ddb8/src/preset/builder/simpleAccount.ts) and [gasLimit.ts](https://github.com/stackup-wallet/userop.js/blob/db3258c5a20cef480d79ec6290094a4a6f89ddb8/src/preset/middleware/gasLimit.ts) with initCode issue.

## Why?

- There is an issue when I want to send the first UO if I've deployed account proxy by calling senderCreator  or AccountFactory.
- It always checks the nonce in EntryPoint in [Here](https://github.com/stackup-wallet/userop.js/blob/db3258c5a20cef480d79ec6290094a4a6f89ddb8/src/preset/builder/simpleAccount.ts#L55). But I think user should be able to use different EntryPoint with same account. 

## How?

- check the account code instead of ctx.op.nonce when setting initCode for UO
- check initCode length before getting factory address from initCode, and return zero for CreationGas if initCode is 0x 

## Testing?
Passed


